### PR TITLE
UHF-8909: Use language manager variable to get current language.

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--hero--with-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--hero--with-search.html.twig
@@ -26,7 +26,7 @@
         {% endif %}
 
         <div class="hero__search-box">
-          <form action="/{{ current_langcode }}/haku" method="get" accept-charset="UTF-8">
+          <form action="/{{ language.id }}/haku" method="get" accept-charset="UTF-8">
             <input data-drupal-selector="edit-search_api_fulltext" type="search" class="hero__search-field" id="edit-search_api_fulltext" name="search_api_fulltext" value="" size="15" placeholder="{{ 'What do you want to know today?'|trans }}" maxlength="128" />
             <input value="{{ 'Search'|trans }}" type="submit" class="hero__search-submit">
           </form>


### PR DESCRIPTION
# [UHF-8909](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8909)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Use language manager variable to get current language.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the front page search submit points to correct translation, I.e. When clicking submit in Finnish, you'll end up on a Finnish translation of the results page.
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/173
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/292
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1028


[UHF-8909]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ