### PR TITLE
UHF-9780: Purger settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,10 @@
         "drupal/helfi_platform_config": "^4.0",
         "drupal/helfi_tpr": "^2.0",
         "drupal/helfi_tunnistamo": "^3.0",
+        "drupal/purge": "^3.6",
         "drupal/raven": "^5.0",
         "drupal/redis": "^1.5",
+        "drupal/varnish_purge": "^2.2",
         "drush/drush": "^12"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec185ba706f49f56522228b6faf70e96",
+    "content-hash": "4d62694c1f6f8e04ec732977a8670cc4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5952,6 +5952,66 @@
             }
         },
         {
+            "name": "drupal/purge",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/purge.git",
+                "reference": "8.x-3.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.6.zip",
+                "reference": "8.x-3.6",
+                "shasum": "f01d53c5a1d34301e86371c70a1d237a517b2897"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.6",
+                    "datestamp": "1719557519",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "branch-alias": {
+                    "dev-8.x-3.x": "3.x-dev"
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": ">=10"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Niels van Mourik",
+                    "homepage": "http://www.nielsvm.org"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "nielsvm",
+                    "homepage": "https://www.drupal.org/user/163285"
+                }
+            ],
+            "description": "Provides a generic external cache invalidation API and queue service.",
+            "homepage": "https://www.drupal.org/project/purge",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge"
+            }
+        },
+        {
             "name": "drupal/raven",
             "version": "5.0.17",
             "source": {
@@ -7238,6 +7298,66 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/twig_tweak",
                 "issues": "https://www.drupal.org/project/issues/twig_tweak"
+            }
+        },
+        {
+            "name": "drupal/varnish_purge",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/varnish_purge.git",
+                "reference": "8.x-2.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/varnish_purge-8.x-2.2.zip",
+                "reference": "8.x-2.2",
+                "shasum": "9fbddb71417113d58345d2fbe9d0a1aa9c5d5c36"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "require-dev": {
+                "drupal/purge": "*",
+                "drupal/purge_tokens": "*",
+                "drupal/varnish_purger-varnish_purger": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.2",
+                    "datestamp": "1681218333",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "deadbeef",
+                    "homepage": "https://www.drupal.org/user/93644"
+                },
+                {
+                    "name": "javivf",
+                    "homepage": "https://www.drupal.org/user/2789335"
+                },
+                {
+                    "name": "littlethoughts",
+                    "homepage": "https://www.drupal.org/user/2479724"
+                },
+                {
+                    "name": "MiSc",
+                    "homepage": "https://www.drupal.org/user/382892"
+                }
+            ],
+            "homepage": "https://www.drupal.org/project/varnish_purge",
+            "support": {
+                "source": "https://git.drupalcode.org/project/varnish_purge"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -114,6 +114,11 @@ module:
   path: 0
   path_alias: 0
   phpass: 0
+  purge: 0
+  purge_drush: 0
+  purge_processor_cron: 0
+  purge_queuer_coretags: 0
+  purge_tokens: 0
   raven: 0
   readonly_field_widget: 0
   redirect: 0
@@ -139,6 +144,8 @@ module:
   translatable_menu_link_uri: 0
   twig_tweak: 0
   user: 0
+  varnish_purge_tags: 0
+  varnish_purger: 0
   view_unpublished: 0
   views_ui: 0
   pathauto: 1

--- a/conf/cmi/purge.logger_channels.yml
+++ b/conf/cmi/purge.logger_channels.yml
@@ -1,0 +1,29 @@
+channels:
+  -
+    id: purgers
+    grants:
+      - 0
+      - 2
+      - 3
+  -
+    id: queue
+    grants:
+      - 0
+      - 2
+      - 3
+  -
+    id: diagnostics
+    grants:
+      - 3
+  -
+    id: purger_varnish_default
+    grants:
+      - 0
+      - 2
+      - 3
+  -
+    id: purger_varnish_varnish_purge_all
+    grants:
+      - 0
+      - 2
+      - 3

--- a/conf/cmi/purge.plugins.yml
+++ b/conf/cmi/purge.plugins.yml
@@ -1,0 +1,29 @@
+purgers:
+  -
+    instance_id: default
+    plugin_id: varnish
+    order_index: 2
+  -
+    instance_id: varnish_purge_all
+    plugin_id: varnish
+    order_index: 3
+processors:
+  -
+    plugin_id: drush_purge_queue_work
+    status: true
+  -
+    plugin_id: cron
+    status: true
+  -
+    plugin_id: drush_purge_invalidate
+    status: true
+queuers:
+  -
+    plugin_id: purge_ui_block_queuer
+    status: false
+  -
+    plugin_id: drush_purge_queue_add
+    status: false
+  -
+    plugin_id: coretags
+    status: true

--- a/conf/cmi/purge_queuer_coretags.settings.yml
+++ b/conf/cmi/purge_queuer_coretags.settings.yml
@@ -1,0 +1,11 @@
+_core:
+  default_config_hash: lupV305oUaexr-RIL2JNFf1YeFYrY3pb5zHL1e6YRWw
+blacklist:
+  - 4xx-response
+  - 'config:core.extension'
+  - extensions
+  - 'config:purge'
+  - theme_registry
+  - 'config:field.storage'
+  - route_match
+  - routes

--- a/conf/cmi/varnish_purger.settings.default.yml
+++ b/conf/cmi/varnish_purger.settings.default.yml
@@ -1,0 +1,28 @@
+uuid: 738a9231-b495-4e5a-81f1-62fa71a4fdec
+langcode: en
+status: true
+dependencies: {  }
+id: default
+name: varnish
+invalidationtype: tag
+hostname: localhost
+port: 6081
+path: /
+request_method: BAN
+scheme: http
+verify: '0'
+headers:
+  -
+    field: Cache-Tags
+    value: '[invalidation:expression]'
+  -
+    field: X-Cache-Tags
+    value: '[invalidation:expression]'
+body: null
+body_content_type: null
+runtime_measurement: true
+timeout: 1.0
+connect_timeout: 1.0
+cooldown_time: 0.0
+max_requests: 100
+http_errors: true

--- a/conf/cmi/varnish_purger.settings.varnish_purge_all.yml
+++ b/conf/cmi/varnish_purger.settings.varnish_purge_all.yml
@@ -1,0 +1,22 @@
+uuid: 097c2d72-fd26-49df-9e1b-12c95939e909
+langcode: en
+status: true
+dependencies: {  }
+id: varnish_purge_all
+name: 'Purge all'
+invalidationtype: everything
+hostname: localhost
+port: 6081
+path: /
+request_method: BAN
+scheme: http
+verify: '0'
+headers: {  }
+body: null
+body_content_type: null
+runtime_measurement: true
+timeout: 1.0
+connect_timeout: 1.0
+cooldown_time: 0.0
+max_requests: 100
+http_errors: true


### PR DESCRIPTION
# [UHF-9780](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9780)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Check purger settings.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9780`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->
This was tricky to test. Our dev image adds the `Set-Cookie: XDEBUG_SESSION=PHPSTORM; path=/; SameSite=Lax` header to all requests, which makes each request bypasses Varnish completely. I logged into the Varnish container and added `unset beresp.http.Set-Cookie;` before `if (beresp.http.Set-Cookie)` in `/etc/varnish/defaults/vcl_backend_response.vcl`. Then I reloaded the Varnish configuration using [these instructions](https://ma.ttias.be/reload-varnish-vcl-without-losing-cache-data/#via-a-custom-script).

Note that after this edit, you will be unable to log in to the site from the Varnish domain.

Afterward, I used these curl commands to check the `x-vc-cache` header in Varnish responses:

* Static assets: curl -kIs "https://varnish-kaupunkitieto.docker.so/themes/contrib/hdbt/dist/js/hyphenopoly/Hyphenopoly_Loader.js?v=5.3.0"
* Drupal nodes: curl -kIs "https://varnish-kaupunkitieto.docker.so/fi/helsingin-tilastotietokannat"

These requests should hit the Varnish cache.

Next, I edited the node at https://varnish-kaupunkitieto.docker.so/fi/helsingin-tilastotietokannat and ran drush `p:queue-browse` to check that the cache tag `node:27` was being cleared. I ran `drush p:queue-work` and verified that the next curl request missed the Varnish cache.


## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-9780]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ