### PR TITLE
UHF-10569 Embed paragraphs

### DIFF
--- a/conf/cmi/core.entity_form_display.paragraph.embed.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.embed.default.yml
@@ -12,7 +12,6 @@ dependencies:
     - paragraphs.paragraphs_type.embed
   module:
     - link
-    - media_library
     - text
 id: paragraph.embed.default
 targetEntityType: paragraph
@@ -21,7 +20,7 @@ mode: default
 content:
   field_embed_code:
     type: string_textfield
-    weight: 3
+    weight: 0
     region: content
     settings:
       size: 60
@@ -29,7 +28,7 @@ content:
     third_party_settings: {  }
   field_embed_code_id:
     type: string_textfield
-    weight: 4
+    weight: 1
     region: content
     settings:
       size: 60
@@ -37,7 +36,7 @@ content:
     third_party_settings: {  }
   field_embed_link:
     type: link_default
-    weight: 5
+    weight: 2
     region: content
     settings:
       placeholder_url: ''
@@ -45,22 +44,15 @@ content:
     third_party_settings: {  }
   field_embed_title:
     type: string_textfield
-    weight: 6
+    weight: 3
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_embed_video:
-    type: media_library_widget
-    weight: 2
-    region: content
-    settings:
-      media_types: {  }
-    third_party_settings: {  }
   field_text_for_screen_readers:
     type: text_textarea
-    weight: 7
+    weight: 4
     region: content
     settings:
       rows: 5
@@ -68,4 +60,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_embed_video: true
   status: true

--- a/conf/cmi/field.field.node.article.field_content.yml
+++ b/conf/cmi/field.field.node.article.field_content.yml
@@ -35,6 +35,7 @@ settings:
       list_of_links: list_of_links
       content_cards: content_cards
       embed: embed
+      remote_video: remote_video
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -82,6 +83,9 @@ settings:
       quick_links_item:
         weight: 35
         enabled: false
+      remote_video:
+        weight: 10
+        enabled: true
       text:
         weight: -27
         enabled: true

--- a/conf/cmi/field.field.paragraph.embed.field_embed_code.yml
+++ b/conf/cmi/field.field.paragraph.embed.field_embed_code.yml
@@ -10,7 +10,7 @@ field_name: field_embed_code
 entity_type: paragraph
 bundle: embed
 label: 'Embed code'
-description: ''
+description: 'The embed code should be in format: https://e.infogram.com/js/dist/embed.js?abc123'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/field.field.paragraph.embed.field_embed_code_id.yml
+++ b/conf/cmi/field.field.paragraph.embed.field_embed_code_id.yml
@@ -10,7 +10,7 @@ field_name: field_embed_code_id
 entity_type: paragraph
 bundle: embed
 label: 'Embed code ID'
-description: 'Script may require ID tag to work properly'
+description: 'The embed code ID should be in format: infogram_0_f0e0c3b7-2752-4ce0-b2ff-720f573d9d2f'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/field.field.paragraph.embed.field_embed_code_id.yml
+++ b/conf/cmi/field.field.paragraph.embed.field_embed_code_id.yml
@@ -10,7 +10,7 @@ field_name: field_embed_code_id
 entity_type: paragraph
 bundle: embed
 label: 'Embed code ID'
-description: 'The embed code ID should be in format: infogram_0_f0e0c3b7-2752-4ce0-b2ff-720f573d9d2f'
+description: 'The embed code ID should be in format: infogram_0_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/field.field.paragraph.embed.field_embed_link.yml
+++ b/conf/cmi/field.field.paragraph.embed.field_embed_link.yml
@@ -12,7 +12,7 @@ field_name: field_embed_link
 entity_type: paragraph
 bundle: embed
 label: 'Embed link'
-description: ''
+description: 'Embed link is intended to be used when embed code and embed code ID fields cannot be used. The embed link should be in format: https://infogram.com/name-for-the-infogram'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/field.field.paragraph.embed.field_text_for_screen_readers.yml
+++ b/conf/cmi/field.field.paragraph.embed.field_text_for_screen_readers.yml
@@ -6,13 +6,17 @@ dependencies:
     - field.storage.paragraph.field_text_for_screen_readers
     - paragraphs.paragraphs_type.embed
   module:
+    - allowed_formats
     - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
 id: paragraph.embed.field_text_for_screen_readers
 field_name: field_text_for_screen_readers
 entity_type: paragraph
 bundle: embed
-label: 'Text for screen readers'
-description: ''
+label: 'Assistive technology title'
+description: 'Users of assistive technology need a descriptive title to know what is in the embedded content.'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_code.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_code.yml
@@ -1,0 +1,2 @@
+label: 'Upotuskoodi'
+description: 'Upotuskoodi tulee olla muotoa: https://e.infogram.com/js/dist/embed.js?abc123'

--- a/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_code_id.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_code_id.yml
@@ -1,0 +1,2 @@
+label: 'Upotuskoodin tunnus'
+description: 'Upotoskoodin tunnus tulee olla muotoa: infogram_0_f0e0c3b7-2752-4ce0-b2ff-720f573d9d2f'

--- a/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_code_id.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_code_id.yml
@@ -1,2 +1,2 @@
 label: 'Upotuskoodin tunnus'
-description: 'Upotoskoodin tunnus tulee olla muotoa: infogram_0_f0e0c3b7-2752-4ce0-b2ff-720f573d9d2f'
+description: 'Upotoskoodin tunnus tulee olla muotoa: infogram_0_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'

--- a/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_link.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_link.yml
@@ -1,0 +1,2 @@
+label: 'Upotuksen URL'
+description: 'Upotuksen URL:ia voidaan käyttää kun upotuskoodi ja upotuskoodin tunnusu kenttiä ei ole saatavilla. Upotuksen URL kenttään voi lisätä vain infogramin URL-osoitteita ja niiden tulee olla muotoa: https://infogram.com/name-for-the-infogram'

--- a/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_link.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_link.yml
@@ -1,2 +1,2 @@
 label: 'Upotuksen URL'
-description: 'Upotuksen URL:ia voidaan käyttää kun upotuskoodi ja upotuskoodin tunnusu kenttiä ei ole saatavilla. Upotuksen URL kenttään voi lisätä vain infogramin URL-osoitteita ja niiden tulee olla muotoa: https://infogram.com/name-for-the-infogram'
+description: 'Upotuksen URL:ia voidaan käyttää kun upotuskoodi ja upotuskoodin tunnus kenttiä ei ole saatavilla. Upotuksen URL kenttään voi lisätä vain infogramin URL-osoitteita ja niiden tulee olla muotoa: https://infogram.com/kaavion-nimi'

--- a/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_title.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.embed.field_embed_title.yml
@@ -1,0 +1,2 @@
+label: 'Upotuksen otsikko'
+description: 'Upotuksen otsikko liitetään Iframe title attribuuttiin kun upotuksen URL kenttä on täytetty. Saavutettavuuden kannalta otsikon täyttäminen on suositeltua.'

--- a/conf/cmi/language/fi/field.field.paragraph.embed.field_text_for_screen_readers.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.embed.field_text_for_screen_readers.yml
@@ -1,0 +1,2 @@
+label: 'Kuvaus avustavalle teknologialle'
+description: 'Kirjoita 1-2 lauseen kuvaus avustavan teknologian käyttäjille.'

--- a/conf/cmi/paragraphs.paragraphs_type.embed.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.embed.yml
@@ -3,8 +3,8 @@ langcode: en
 status: true
 dependencies: {  }
 id: embed
-label: Embed
+label: 'Infogram Embed'
 icon_uuid: null
 icon_default: null
-description: 'Embed content from an external source, such as YouTube and Power BI.'
+description: 'Embed content from Infogram'
 behavior_plugins: {  }

--- a/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.info.yml
@@ -4,3 +4,5 @@ core_version_requirement: ^10
 dependencies:
   - helfi_platform_config:helfi_platform_config
   - helfi_tunnistamo:helfi_tunnistamo
+'interface translation project': kaupunkitieto_config
+'interface translation server pattern': modules/custom/kaupunkitieto_config/translations/%language.po

--- a/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.module
+++ b/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.module
@@ -7,24 +7,6 @@
 
 declare(strict_types=1);
 
-use Drupal\config_rewrite\ConfigRewriterInterface;
-
-/**
- * Implements hook_rewrite_config_update().
- */
-function kaupunkitieto_config_rewrite_config_update(string $module, ConfigRewriterInterface $configRewriter): void {
-  $modules = [
-    'helfi_node_landing_page',
-    'helfi_node_page',
-    'helfi_paragraphs_content_cards',
-  ];
-
-  if (in_array($module, $modules)) {
-    // Rewrite module configuration.
-    $configRewriter->rewriteModuleConfig('kaupunkitieto_config');
-  }
-}
-
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
  */

--- a/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.module
+++ b/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.module
@@ -7,10 +7,29 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\kaupunkitieto_config\Plugin\Validation\Constraint\EmbedConstraints;
+
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
-function kaupunkitieto_config_form_node_form_alter(array &$form) {
+function kaupunkitieto_config_form_node_form_alter(array &$form): void {
   // Attach content liftup library to node forms.
   $form['#attached']['library'][] = 'kaupunkitieto_config/admin-content-liftup';
+}
+
+/**
+ * Implements hook_entity_bundle_field_info_alter().
+ */
+function kaupunkitieto_config_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle): void {
+  if ($entity_type->id() !== 'paragraph' || $bundle !== 'embed') {
+    return;
+  }
+
+  // Add constraints to embed paragraph fields.
+  foreach ($fields as $name => $field) {
+    if (in_array($name, EmbedConstraints::EMBED_FIELDS)) {
+      $field->addConstraint('EmbedConstraints', []);
+    }
+  }
 }

--- a/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.module
+++ b/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.module
@@ -28,7 +28,7 @@ function kaupunkitieto_config_entity_bundle_field_info_alter(&$fields, EntityTyp
 
   // Add constraints to embed paragraph fields.
   foreach ($fields as $name => $field) {
-    if (in_array($name, EmbedConstraints::EMBED_FIELDS)) {
+    if (in_array($name, array_keys(EmbedConstraints::EMBED_FIELDS))) {
       $field->addConstraint('EmbedConstraints', []);
     }
   }

--- a/public/modules/custom/kaupunkitieto_config/modules/aet/aet.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/aet/aet.info.yml
@@ -1,3 +1,0 @@
-name: 'aet - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/config_update/config_update.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/config_update/config_update.info.yml
@@ -1,3 +1,0 @@
-name: 'config_update - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/features/features.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/features/features.info.yml
@@ -1,3 +1,0 @@
-name: 'AET - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/hdbt_admin_editorial/hdbt_admin_editorial.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/hdbt_admin_editorial/hdbt_admin_editorial.info.yml
@@ -1,3 +1,0 @@
-name: 'hdbt_admin_editorial - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/hdbt_component_library/hdbt_component_library.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/hdbt_component_library/hdbt_component_library.info.yml
@@ -1,3 +1,0 @@
-name: 'hdbt_component_library - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/hdbt_content/hdbt_content.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/hdbt_content/hdbt_content.info.yml
@@ -1,3 +1,0 @@
-name: 'hdbt_content - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/hdbt_hyphenopoly/hdbt_hyphenopoly.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/hdbt_hyphenopoly/hdbt_hyphenopoly.info.yml
@@ -1,3 +1,0 @@
-name: 'hdbt_hyphenopoly - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/helfi_charts/helfi_charts.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/helfi_charts/helfi_charts.info.yml
@@ -1,3 +1,0 @@
-name: 'helfi_charts - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/helfi_contact_cards/helfi_contact_cards.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/helfi_contact_cards/helfi_contact_cards.info.yml
@@ -1,3 +1,0 @@
-name: 'helfi_contact_cards - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/helfi_content/helfi_content.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/helfi_content/helfi_content.info.yml
@@ -1,3 +1,0 @@
-name: 'helfi_content - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/helfi_events/helfi_events.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/helfi_events/helfi_events.info.yml
@@ -1,3 +1,0 @@
-name: 'helfi_events - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/helfi_example_content/helfi_example_content.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/helfi_example_content/helfi_example_content.info.yml
@@ -1,3 +1,0 @@
-name: 'helfi_example_content - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/helfi_gdpr_compliance/helfi_gdpr_compliance.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/helfi_gdpr_compliance/helfi_gdpr_compliance.info.yml
@@ -1,3 +1,0 @@
-name: 'helfi_gdpr_compliance - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/helfi_languages/helfi_languages.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/helfi_languages/helfi_languages.info.yml
@@ -1,3 +1,0 @@
-name: 'helfi_languages - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/select2_icon/select2_icon.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/select2_icon/select2_icon.info.yml
@@ -1,3 +1,0 @@
-name: 'select2_icon - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/token_filter/token_filter.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/token_filter/token_filter.info.yml
@@ -1,3 +1,0 @@
-name: 'token_filter - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/modules/update_helper/update_helper.info.yml
+++ b/public/modules/custom/kaupunkitieto_config/modules/update_helper/update_helper.info.yml
@@ -1,3 +1,0 @@
-name: 'update_helper - dummy module'
-type: module
-core_version_requirement: ^9 || ^10

--- a/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraints.php
+++ b/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraints.php
@@ -70,4 +70,11 @@ class EmbedConstraints extends Constraint {
    */
   public string $embedLinkNotValid = 'The embed link must start with %value. For example: %value/abc123';
 
+  /**
+   * Message for the embed link should not be filled.
+   *
+   * @var string
+   */
+  public string $embedShouldNotBeFilled = 'Embed link should be empty when an embed code or embed code ID is filled.';
+
 }

--- a/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraints.php
+++ b/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraints.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\kaupunkitieto_config\Plugin\Validation\Constraint;
 
-use Symfony\Component\Validator\Constraint;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Validation\Attribute\Constraint;
+use Symfony\Component\Validator\Constraint as SymfonyConstraint;
 
 /**
  * Checks that the fields are valid in embed paragraph.
- *
- * @Constraint(
- *   id = "EmbedConstraints",
- *   label = @Translation("Fields are not valid.", context = "Validation"),
- * )
  */
-class EmbedConstraints extends Constraint {
+#[Constraint(
+  id: 'EmbedConstraints',
+  label: new TranslatableMarkup('Fields are not valid.', [], ['context' => 'Validation']),
+)]
+class EmbedConstraints extends SymfonyConstraint {
 
   /**
    * Embed fields and corresponding error message keys.

--- a/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraints.php
+++ b/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraints.php
@@ -28,6 +28,17 @@ class EmbedConstraints extends Constraint {
   ];
 
   /**
+   * Embed fields and corresponding error message keys.
+   *
+   * @var string[]
+   */
+  public const VALID_VALUES = [
+    'field_embed_code' => 'https://e.infogram.com/js/dist/embed.js?abc123',
+    'field_embed_code_id' => 'infogram_0_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+    'field_embed_link' => 'https://infogram.com',
+  ];
+
+  /**
    * Validation patterns for each embed field.
    *
    * @var string[]
@@ -43,20 +54,20 @@ class EmbedConstraints extends Constraint {
    *
    * @var string
    */
-  public string $embedCodeNotValid = 'The embed code must be as follows: https://e.infogram.com/js/dist/embed.js?abc123';
+  public string $embedCodeNotValid = 'The embed code must be as follows: %value';
 
   /**
    * Message for the embed code.
    *
    * @var string
    */
-  public string $embedCodeIdNotValid = 'The embed code ID must be as follows: infogram_0_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+  public string $embedCodeIdNotValid = 'The embed code ID must be as follows: %value';
 
   /**
    * Message for the embed code.
    *
    * @var string
    */
-  public string $embedLinkNotValid = 'The embed link must start with https://infogram.com/. For example: https://infogram.com/abc123';
+  public string $embedLinkNotValid = 'The embed link must start with %value. For example: %value/abc123';
 
 }

--- a/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraints.php
+++ b/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraints.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\kaupunkitieto_config\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks that the fields are valid in embed paragraph.
+ *
+ * @Constraint(
+ *   id = "EmbedConstraints",
+ *   label = @Translation("Fields are not valid.", context = "Validation"),
+ * )
+ */
+class EmbedConstraints extends Constraint {
+
+  /**
+   * Embed fields and corresponding error message keys.
+   *
+   * @var string[]
+   */
+  public const EMBED_FIELDS = [
+    'field_embed_code' => 'embedCodeNotValid',
+    'field_embed_code_id' => 'embedCodeIdNotValid',
+    'field_embed_link' => 'embedLinkNotValid',
+  ];
+
+  /**
+   * Validation patterns for each embed field.
+   *
+   * @var string[]
+   */
+  public const VALIDATION_PATTERNS = [
+    'field_embed_code' => '#^https://e\.infogram\.com/js/dist/embed\.js\?.+#',
+    'field_embed_code_id' => '#^infogram_#',
+    'field_embed_link' => '#^https://infogram\.com/#',
+  ];
+
+  /**
+   * Message for the embed code.
+   *
+   * @var string
+   */
+  public string $embedCodeNotValid = 'The embed code must be as follows: https://e.infogram.com/js/dist/embed.js?abc123';
+
+  /**
+   * Message for the embed code.
+   *
+   * @var string
+   */
+  public string $embedCodeIdNotValid = 'The embed code ID must be as follows: infogram_0_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+  /**
+   * Message for the embed code.
+   *
+   * @var string
+   */
+  public string $embedLinkNotValid = 'The embed link must start with https://infogram.com/. For example: https://infogram.com/abc123';
+
+}

--- a/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraintsValidator.php
+++ b/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraintsValidator.php
@@ -38,7 +38,8 @@ class EmbedConstraintsValidator extends ConstraintValidator {
       ]);
     }
 
-    $parent = $value->getParent();
+    /** @var \Drupal\Core\Entity\ContentEntityInterface|null $parent */
+    $parent = $value->getParent()?->getValue();
 
     // Handle only field_embed_link field.
     if (!$parent || $value->getName() !== 'field_embed_link' || $value->isEmpty()) {

--- a/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraintsValidator.php
+++ b/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraintsValidator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\kaupunkitieto_config\Plugin\Validation\Constraint;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the Embed constraints.
+ */
+class EmbedConstraintsValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate(mixed $value, Constraint $constraint): void {
+    assert($constraint instanceof EmbedConstraints);
+
+    // Only handle embed fields.
+    if (
+      !$value instanceof FieldItemListInterface ||
+      !in_array($value->getName(), array_keys(EmbedConstraints::EMBED_FIELDS)) ||
+      $value->isEmpty()
+    ) {
+      return;
+    }
+
+    // Add violation if the value doesn't match the pattern.
+    if (
+      isset(EmbedConstraints::VALIDATION_PATTERNS[$value->getName()]) &&
+      !preg_match(EmbedConstraints::VALIDATION_PATTERNS[$value->getName()], $value->getString())
+    ) {
+      $this->context->addViolation($constraint->{EmbedConstraints::EMBED_FIELDS[$value->getName()]});
+    }
+  }
+
+}

--- a/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraintsValidator.php
+++ b/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraintsValidator.php
@@ -37,6 +37,22 @@ class EmbedConstraintsValidator extends ConstraintValidator {
         '%value' => EmbedConstraints::VALID_VALUES[$value->getName()],
       ]);
     }
+
+    $parent = $value->getParent();
+
+    // Handle only field_embed_link field.
+    if (!$parent || $value->getName() !== 'field_embed_link' || $value->isEmpty()) {
+      return;
+    }
+
+    // Add violation if the embed link has value when the embed code and
+    // embed code ID are filled.
+    if (
+      !$parent->get('field_embed_code')->isEmpty() ||
+      !$parent->get('field_embed_code_id')->isEmpty()
+    ) {
+      $this->context->addViolation($constraint->embedShouldNotBeFilled);
+    }
   }
 
 }

--- a/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraintsValidator.php
+++ b/public/modules/custom/kaupunkitieto_config/src/Plugin/Validation/Constraint/EmbedConstraintsValidator.php
@@ -33,7 +33,9 @@ class EmbedConstraintsValidator extends ConstraintValidator {
       isset(EmbedConstraints::VALIDATION_PATTERNS[$value->getName()]) &&
       !preg_match(EmbedConstraints::VALIDATION_PATTERNS[$value->getName()], $value->getString())
     ) {
-      $this->context->addViolation($constraint->{EmbedConstraints::EMBED_FIELDS[$value->getName()]});
+      $this->context->addViolation($constraint->{EmbedConstraints::EMBED_FIELDS[$value->getName()]}, [
+        '%value' => EmbedConstraints::VALID_VALUES[$value->getName()],
+      ]);
     }
   }
 

--- a/public/modules/custom/kaupunkitieto_config/tests/src/Unit/EmbedConstraintsValidatorTest.php
+++ b/public/modules/custom/kaupunkitieto_config/tests/src/Unit/EmbedConstraintsValidatorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\kaupunkitieto_config\Unit;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\kaupunkitieto_config\Plugin\Validation\Constraint\EmbedConstraints;
+use Drupal\kaupunkitieto_config\Plugin\Validation\Constraint\EmbedConstraintsValidator;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * Unit test for EmbedConstraintsValidator.
+ *
+ * @group kaupunkitieto_config
+ */
+class EmbedConstraintsValidatorTest extends ConstraintValidatorTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function createValidator(): EmbedConstraintsValidator {
+    return new EmbedConstraintsValidator();
+  }
+
+  /**
+   * Tests valid values.
+   */
+  public function testValidValues(): void {
+    $valid_values = [
+      'field_embed_code' => 'https://e.infogram.com/js/dist/embed.js?valid123',
+      'field_embed_code_id' => 'infogram_0_abc1234-5678-9101-1121-314151617181',
+      'field_embed_link' => 'https://infogram.com/valid-link',
+    ];
+
+    foreach ($valid_values as $field_name => $valid_value) {
+      $field = $this->createFieldMock($field_name, $valid_value);
+      $this->validator->validate($field, new EmbedConstraints());
+
+      // No violations should be triggered.
+      $this->assertNoViolation();
+    }
+  }
+
+  /**
+   * Tests invalid values.
+   */
+  public function testInvalidValues(): void {
+    $invalid_values = [
+      'field_embed_code' => ['invalid_value', 'embedCodeNotValid'],
+      'field_embed_code_id' => ['wrong_prefix_abc123', 'embedCodeIdNotValid'],
+      'field_embed_link' => ['http://wrong-url.com/abc123', 'embedLinkNotValid'],
+    ];
+
+    foreach ($invalid_values as $field_name => [$invalid_value, $error_message_key]) {
+      $constraint = new EmbedConstraints();
+      $expected_message = $constraint->$error_message_key;
+
+      $field = $this->createFieldMock($field_name, $invalid_value);
+      $this->setUp();
+      $this->validator->validate($field, $constraint);
+      $this->assertCount(1, $this->context->getViolations());
+      $this->assertEquals($expected_message, $this->context->getViolations()[0]->getMessage());
+      $this->context->getViolations()->remove(1);
+    }
+  }
+
+  /**
+   * Tests empty field values.
+   */
+  public function testEmptyField(): void {
+    $field = $this->createMock(FieldItemListInterface::class);
+    $field->method('getName')->willReturn('field_embed_code');
+    $field->method('isEmpty')->willReturn(TRUE);
+
+    $this->validator->validate($field, new EmbedConstraints());
+
+    $this->assertNoViolation();
+  }
+
+  /**
+   * Creates a mock FieldItemListInterface object.
+   */
+  private function createFieldMock(string $name, string $value): MockObject {
+    $field = $this->createMock(FieldItemListInterface::class);
+    $field->method('getName')->willReturn($name);
+    $field->method('getString')->willReturn($value);
+    $field->method('isEmpty')->willReturn(FALSE);
+    return $field;
+  }
+
+}

--- a/public/modules/custom/kaupunkitieto_config/tests/src/Unit/EmbedConstraintsValidatorTest.php
+++ b/public/modules/custom/kaupunkitieto_config/tests/src/Unit/EmbedConstraintsValidatorTest.php
@@ -87,8 +87,14 @@ class EmbedConstraintsValidatorTest extends ConstraintValidatorTestCase {
 
     $parent = $this->createMock(FieldItemListInterface::class);
     $parent->method('get')->willReturnMap([
-      ['field_embed_code', $this->createFieldMock('field_embed_code', 'https://e.infogram.com/js/dist/embed.js?valid123')],
-      ['field_embed_code_id', $this->createFieldMock('field_embed_code_id', 'infogram_0_abc1234-5678-9101-1121-314151617181')],
+      [
+        'field_embed_code',
+        $this->createFieldMock('field_embed_code', 'https://e.infogram.com/js/dist/embed.js?valid123'),
+      ],
+      [
+        'field_embed_code_id',
+        $this->createFieldMock('field_embed_code_id', 'infogram_0_abc1234-5678-9101-1121-314151617181'),
+      ],
     ]);
 
     $field_embed_link = $this->createMock(FieldItemListInterface::class);

--- a/public/modules/custom/kaupunkitieto_config/tests/src/Unit/EmbedConstraintsValidatorTest.php
+++ b/public/modules/custom/kaupunkitieto_config/tests/src/Unit/EmbedConstraintsValidatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\kaupunkitieto_config\Unit;
 
+use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\kaupunkitieto_config\Plugin\Validation\Constraint\EmbedConstraints;
 use Drupal\kaupunkitieto_config\Plugin\Validation\Constraint\EmbedConstraintsValidator;
@@ -97,10 +98,13 @@ class EmbedConstraintsValidatorTest extends ConstraintValidatorTestCase {
       ],
     ]);
 
+    $entity_adapter = $this->createMock(EntityAdapter::class);
+    $entity_adapter->method('getValue')->willReturn($parent);
+
     $field_embed_link = $this->createMock(FieldItemListInterface::class);
     $field_embed_link->method('getName')->willReturn('field_embed_link');
     $field_embed_link->method('isEmpty')->willReturn(FALSE);
-    $field_embed_link->method('getParent')->willReturn($parent);
+    $field_embed_link->method('getParent')->willReturn($entity_adapter);
     $field_embed_link->method('getString')->willReturn('https://infogram.com/valid-link');
 
     $this->validator->validate($field_embed_link, $constraint);

--- a/public/modules/custom/kaupunkitieto_config/tests/src/Unit/EmbedConstraintsValidatorTest.php
+++ b/public/modules/custom/kaupunkitieto_config/tests/src/Unit/EmbedConstraintsValidatorTest.php
@@ -80,6 +80,30 @@ class EmbedConstraintsValidatorTest extends ConstraintValidatorTestCase {
   }
 
   /**
+   * Tests that field_embed_link should be empty when embed fields are filled.
+   */
+  public function testEmbedShouldNotBeFilled(): void {
+    $constraint = new EmbedConstraints();
+
+    $parent = $this->createMock(FieldItemListInterface::class);
+    $parent->method('get')->willReturnMap([
+      ['field_embed_code', $this->createFieldMock('field_embed_code', 'https://e.infogram.com/js/dist/embed.js?valid123')],
+      ['field_embed_code_id', $this->createFieldMock('field_embed_code_id', 'infogram_0_abc1234-5678-9101-1121-314151617181')],
+    ]);
+
+    $field_embed_link = $this->createMock(FieldItemListInterface::class);
+    $field_embed_link->method('getName')->willReturn('field_embed_link');
+    $field_embed_link->method('isEmpty')->willReturn(FALSE);
+    $field_embed_link->method('getParent')->willReturn($parent);
+    $field_embed_link->method('getString')->willReturn('https://infogram.com/valid-link');
+
+    $this->validator->validate($field_embed_link, $constraint);
+
+    $this->assertCount(1, $this->context->getViolations());
+    $this->assertEquals($constraint->embedShouldNotBeFilled, $this->context->getViolations()[0]->getMessage());
+  }
+
+  /**
    * Creates a mock FieldItemListInterface object.
    */
   private function createFieldMock(string $name, string $value): MockObject {

--- a/public/modules/custom/kaupunkitieto_config/translations/fi.po
+++ b/public/modules/custom/kaupunkitieto_config/translations/fi.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+
+msgid "The embed code must be as follows: %value"
+msgstr "Upotuskoodin tulee olla muotoa: %value"
+
+msgid "The embed code ID must be as follows: %value"
+msgstr "Upotoskoodin tunnus tulee olla muotoa: %value"
+
+msgid "The embed link must start with %value. For example: %value/abc123"
+msgstr "Upotuksen URL pitää alkaa %value. Esimerkiksi: %value/abc123"

--- a/public/modules/custom/kaupunkitieto_config/translations/fi.po
+++ b/public/modules/custom/kaupunkitieto_config/translations/fi.po
@@ -8,4 +8,7 @@ msgid "The embed code ID must be as follows: %value"
 msgstr "Upotoskoodin tunnus tulee olla muotoa: %value"
 
 msgid "The embed link must start with %value. For example: %value/abc123"
-msgstr "Upotuksen URL pitää alkaa %value. Esimerkiksi: %value/abc123"
+msgstr "Upotuksen URL -kentän arvo pitää alkaa %value. Esimerkiksi: %value/abc123"
+
+msgid "Embed link should be empty when an embed code or embed code ID is filled."
+msgstr "Upotuksen URL -kenttä tulee olla tyhjä jos Upotuskoodi tai Upotuskoodin tunnus on täytetty."

--- a/public/modules/custom/kaupunkitieto_config/translations/sv.po
+++ b/public/modules/custom/kaupunkitieto_config/translations/sv.po
@@ -9,3 +9,6 @@ msgstr "Inbäddningskodens ID måste ha följande format: %value"
 
 msgid "The embed link must start with %value. For example: %value/abc123"
 msgstr "Inbäddningslänken måste börja med %value. Exempel: %value/abc123"
+
+msgid "Embed link should be empty when an embed code or embed code ID is filled."
+msgstr "Inbäddningslänk ska vara tom när en inbäddningskod eller inbäddningskod-ID fylls i."

--- a/public/modules/custom/kaupunkitieto_config/translations/sv.po
+++ b/public/modules/custom/kaupunkitieto_config/translations/sv.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+
+msgid "The embed code must be as follows: %value"
+msgstr "Inbäddningskoden måste ha följande format: %value"
+
+msgid "The embed code ID must be as follows: %value"
+msgstr "Inbäddningskodens ID måste ha följande format: %value"
+
+msgid "The embed link must start with %value. For example: %value/abc123"
+msgstr "Inbäddningslänken måste börja med %value. Exempel: %value/abc123"

--- a/public/modules/custom/kaupunkitieto_infograph/drush.services.yml
+++ b/public/modules/custom/kaupunkitieto_infograph/drush.services.yml
@@ -14,3 +14,8 @@ services:
     arguments: ['@module_handler', '@entity_type.manager', '@database']
     tags:
       - { name: drush.command }
+  kaupunkitieto_infograph.migrate_paragraphs:
+    class: \Drupal\kaupunkitieto_infograph\Commands\MigrateEmbedParagraphs
+    arguments: ['@entity_type.manager', '@database', '@logger.factory']
+    tags:
+      - { name: drush.command }

--- a/public/modules/custom/kaupunkitieto_infograph/src/Commands/MigrateEmbedParagraphs.php
+++ b/public/modules/custom/kaupunkitieto_infograph/src/Commands/MigrateEmbedParagraphs.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\kaupunkitieto_infograph\Commands;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\media\Entity\Media;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drush\Attributes\Command;
+use Drush\Attributes\Usage;
+use Drush\Commands\AutowireTrait;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A Drush commandfile.
+ */
+final class MigrateEmbedParagraphs extends DrushCommands {
+
+  use AutowireTrait;
+  use DependencySerializationTrait;
+
+  /**
+   * The paragraph storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected EntityStorageInterface $paragraphStorage;
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected EntityStorageInterface $nodeStorage;
+
+  /**
+   * Constructs a KaupunkitietoMigrateParagraphs object.
+   */
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly Connection $connection,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {
+    parent::__construct();
+    $this->paragraphStorage = $this->entityTypeManager->getStorage('paragraph');
+    $this->nodeStorage = $this->entityTypeManager->getStorage('node');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('database'),
+      $container->get('logger.factory'),
+    );
+  }
+
+  /**
+   * Converts Embed paragraphs to Chart paragraphs.
+   */
+  #[Command(name: 'kaupunkitieto:migrate-embed-paragraphs')]
+  #[Usage(name: 'kaupunkitieto:migrate-embed-paragraphs', description: 'Running the command will migrate Embed paragraphs with app.powerbi.com URLs to chart paragraphs.')]
+  public function commandName() {
+    $query = $this->connection->select('paragraph__field_embed_link', 'p')
+      ->fields('p', ['entity_id'])
+      ->condition('p.field_embed_link_uri', '%app.powerbi.com%', 'LIKE');
+
+    // Embed paragraphs with app.powerbi.com URLs.
+    $paragraph_ids = $query->execute()->fetchCol();
+
+    if (!$paragraph_ids) {
+      $this->loggerFactory->get('kaupunkitieto_config')->notice('No Embed paragraphs with app.powerbi.com found.');
+      return;
+    }
+
+    // If Embed paragraphs with app.powerbi.com URLs are found, migrate them.
+    foreach ($paragraph_ids as $paragraph_id) {
+      // Get parent references.
+      $query = $this->connection->select('paragraphs_item_field_data', 'pi')
+        ->fields('pi', ['parent_id', 'parent_type', 'parent_field_name'])
+        ->condition('pi.id', $paragraph_id)
+        ->condition('pi.type', 'embed');
+      $parents = $query->execute()->fetchAssoc();
+
+      if ($parents) {
+        $this->processMigration($parents, $paragraph_id);
+      }
+    }
+  }
+
+  /**
+   * Process the migration.
+   *
+   * @param array $parent_entity
+   *   Parent entity, either a node or another paragraph.
+   * @param string $paragraph_id
+   *   Embed paragraph to be converted.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  protected function processMigration(array $parent_entity, string $paragraph_id): void {
+    $embed_paragraph = Paragraph::load($paragraph_id);
+
+    $parent_id = $parent_entity['parent_id'];
+    $parent_type = $parent_entity['parent_type'];
+    $parent_field = $parent_entity['parent_field_name'];
+
+    if ($parent_type === 'node') {
+      /** @var \Drupal\node\NodeInterface $parent_entity */
+      $parent_entity = $this->nodeStorage->load($parent_id);
+    }
+    else {
+      /** @var \Drupal\paragraphs\ParagraphInterface $parent_entity */
+      $parent_entity = $this->paragraphStorage->load($parent_id);
+    }
+
+    if ($parent_entity) {
+      $paragraphs = $parent_entity->get($parent_field)->getValue();
+      $save = FALSE;
+
+      // Replace the reference to the Embed paragraph with
+      // the new Video paragraph.
+      foreach ($paragraphs as &$paragraph) {
+        if ($paragraph['target_id'] == $embed_paragraph->id()) {
+          // Construct a title for the media entity.
+          // @phpstan-ignore-next-line
+          $title = $embed_paragraph->getParentEntity()->getTitle()
+            ?? $embed_paragraph->getParentEntity()->id();
+
+          // Create the chart media entity.
+          $chart_media = Media::create([
+            'bundle' => 'helfi_chart',
+            'name' => $title,
+            'langcode' => $embed_paragraph->language()->getId(),
+            'field_helfi_chart_url' => [
+              [
+                'uri' => $embed_paragraph->get('field_embed_link')->first(
+                )->getString(),
+              ],
+            ],
+            'field_helfi_chart_title' => [
+              'value' => $title,
+            ],
+          ]);
+          $chart_media->save();
+
+          // Create a new Chart paragraph.
+          $chart_paragraph = Paragraph::create([
+            'type' => 'chart',
+            'field_chart_chart' => [
+              'target_id' => $chart_media->id(),
+            ],
+            'langcode' => $embed_paragraph->language()->getId(),
+          ]);
+          $chart_paragraph->save();
+
+          $paragraph['target_id'] = $chart_paragraph->id();
+          $paragraph['target_revision_id'] = $chart_paragraph->getRevisionId();
+          $save = TRUE;
+          break;
+        }
+      }
+
+      // Set the new chart paragraphs to the parent entity and save.
+      if ($save) {
+        $parent_entity->set($parent_field, $paragraphs);
+        $parent_entity->save();
+
+        // Set the old Embed paragraph unpublished.
+        $embed_paragraph->setUnpublished();
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
# [UHF-10569](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10569)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed video embed field from Embed paragraph, as the same functionality is provided by the `helfi_paragraphs_remote_video`.
* Added a drush command for migrating the embed paragraphs to chart paragraphs.
* Added validators for the embed paragraph fields and translated Infogram embed fields.
* Let content producer to add remote video paragraphs to articles.
* Removed stale hook and dummy modules, which were used for updating platform config to version 3.*.

## How to install

* Make sure your instance is up and running on dev branch.
  * `git checkout dev`
  * `make fresh`
* Switch to this branch
  * `git checkout UHF-10569`
* Run `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Log in and go to add a landing page: https://kaupunkitieto.docker.so/fi/node/add/landing_page
* Fill in the required fields and add an Embed (Upotus) paragraph to the page
   * Check that there is no "Video embed field" in the paragraph
   * Fill in the embed paragraph with random information and try to save the page. This should lead in to an error which explains what's wrong with the fields. For example: 
     <img width="733" alt="image" src="https://github.com/user-attachments/assets/03b657fa-8b5e-4534-998f-9936ea14f2d0" />

   * Fill in the embed paragraph with correct embed code and embed code id information and check that an embed paragraph with infogram information can be added. 
      * Embed code (Upotuskoodi): `https://e.infogram.com/js/dist/embed.js?y97`
      * Embed code ID (Upotuskoodin tunnus): `infogram_0_ef169b27-8bf0-4606-ad56-55363e27e8df`
   * Fill in the Embed link (Upotuksen URL) to the same paragraph: `https://infogram.com/kuvio-51-1h7g6kynzwg04oy`
      * You shouldn't be able to save the page since the embed link and embed code fields cannot be filled at the same time. Remove the Embed code and Embed code ID fields and try to save the page, it should now get saved.

### How to test the Embed -> Chart migration
* Go to container and run 
```
drush sqlq "select count(*) from paragraph__field_embed_link h join paragraphs_item_field_data p on h.entity_id = p.id where h.field_embed_link_uri like '%app.powerbi.com%'"
```
   * This should return a count of PowerBI embed paragraphs.
   * Run `drush kaupunkitieto:migrate-embed-paragraphs`
      * This will convert the Embed paragraphs to Chart paragraphs. You can inspect the paragraphs/pages by command clicking the URLs.
   * Run the SQL query again and check how many paragraphs are left. There should be only three left and these three are needed to convert manually.
* Check that code follows our standards


[UHF-10569]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ