### PR TITLE
UHF-12006: Fix search page inputfield autofill

### DIFF
--- a/public/modules/custom/kaupunkitieto_search/templates/header-search.html.twig
+++ b/public/modules/custom/kaupunkitieto_search/templates/header-search.html.twig
@@ -6,7 +6,7 @@
           <label class="hds-text-input__label" for="search-form-kaupunkitieto">{{ label }}</label>
         {% endif %}
         <div class="hds-text-input__input-wrapper">
-          <input type="search" id="search-form-kaupunkitieto" name="q" value="" size="30" maxlength="128" class="form-text hds-text-input__input" placeholder="{{ 'What are you looking for?'|t }}">
+          <input type="search" id="search-form-kaupunkitieto" name="search_api_fulltext" value="" size="30" maxlength="128" class="form-text hds-text-input__input" placeholder="{{ 'What are you looking for?'|t }}">
         </div>
       </div>
       <button class="hds-button hds-button--primary helfi-search__submit-button" type="submit" value="Submit">


### PR DESCRIPTION
# [UHF-12006](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12006)

## What was done
- Changed the header search input name


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12006`
  * `make fresh`
* Run `make drush-cr`


## How to test
- Run elasticsearch index rebuild, clear and indexing if you want real results
- Go to any page
- Use the search functionality located in the top of the page 
- When you are redirected to search page, the search-page text-input field should have been prefilled with the text you put in the header search field



[UHF-12006]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ