### PR TITLE
UHF-12008: Fix author links in recent article listing

### DIFF
--- a/conf/cmi/views.view.article.yml
+++ b/conf/cmi/views.view.article.yml
@@ -28,6 +28,72 @@ display:
     display_options:
       title: 'Recent articles'
       fields:
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: field_language
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '{{ langcode__value }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         nid:
           id: nid
           table: node_field_data
@@ -310,7 +376,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: ' | <a href="/haku?filter[0]=author:{{ field_author_1__target_id }}">{{ field_author_1 }}</a>'
+            text: ' | <a href="/{{ langcode }}/haku?filter[0]=author:{{ field_author_1__target_id }}">{{ field_author_1 }}</a>'
             make_link: false
             path: ''
             absolute: false


### PR DESCRIPTION
# [UHF-12008](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12008)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed author links in recent article listing by adding the current lancode to the url.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12008`
  * `make fresh`
* Run `make drush-cim drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that author links on the front page https://kaupunkitieto.docker.so/fi recent articles block work. You can test how they are broken in production.
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation


[UHF-12008]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ