### PR TITLE
UHF-11974: Adding CSP directives needed for infogram embeds.

### DIFF
--- a/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.services.yml
+++ b/public/modules/custom/kaupunkitieto_config/kaupunkitieto_config.services.yml
@@ -4,3 +4,6 @@ services:
     autoconfigure: true
 
   Drupal\kaupunkitieto_config\EventSubscriber\TunnistamoRedirectUrlSubscriber: ~
+
+  Drupal\kaupunkitieto_config\EventSubscriber\CspEventSubscriber:
+      class: Drupal\kaupunkitieto_config\EventSubscriber\CspEventSubscriber

--- a/public/modules/custom/kaupunkitieto_config/src/EventSubscriber/CspEventSubscriber.php
+++ b/public/modules/custom/kaupunkitieto_config/src/EventSubscriber/CspEventSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\kaupunkitieto_config\EventSubscriber;
+
+use Drupal\csp\CspEvents;
+use Drupal\csp\Event\PolicyAlterEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for CSP policy alteration.
+ *
+ * @package Drupal\kaupunkitieto_config\EventSubscriber
+ */
+class CspEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events = [];
+
+    if (class_exists(CspEvents::class)) {
+      $events[CspEvents::POLICY_ALTER] = 'policyAlter';
+    }
+
+    return $events;
+  }
+
+  /**
+   * Alter CSP policies.
+   *
+   * @param \Drupal\csp\Event\PolicyAlterEvent $event
+   *   The policy alter event.
+   */
+  public function policyAlter(PolicyAlterEvent $event): void {
+    $policy = $event->getPolicy();
+    $policy->fallbackAwareAppendIfEnabled('frame-src', [
+      'https://e.infogram.com',
+      'https://infogram.com',
+    ]);
+    $policy->fallbackAwareAppendIfEnabled('script-src', [
+      'https://e.infogram.com',
+    ]);
+  }
+
+}

--- a/public/modules/custom/kaupunkitieto_config/tests/src/Unit/CspEventSubscriberTest.php
+++ b/public/modules/custom/kaupunkitieto_config/tests/src/Unit/CspEventSubscriberTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\kaupunkitieto_config\Unit;
+
+use DG\BypassFinals;
+use Drupal\csp\Csp;
+use Drupal\csp\CspEvents;
+use Drupal\csp\Event\PolicyAlterEvent;
+use Drupal\kaupunkitieto_config\EventSubscriber\CspEventSubscriber;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * Unit tests for CspEventSubscriber.
+ *
+ * @group kaupunkitieto_config
+ * @coversDefaultClass \Drupal\kaupunkitieto_config\EventSubscriber\CspEventSubscriber
+ */
+class CspEventSubscriberTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * The CspEventSubscriber.
+   *
+   * @var \Drupal\kaupunkitieto_config\EventSubscriber\CspEventSubscriber
+   */
+  protected CspEventSubscriber $cspEventSubscriber;
+
+  /**
+   * The Event.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected ObjectProphecy $event;
+
+  /**
+   * The Csp policy.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected ObjectProphecy $policy;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    BypassFinals::enable();
+
+    $this->event = $this->prophesize(PolicyAlterEvent::class);
+    $this->policy = $this->prophesize(Csp::class);
+    $this->event->getPolicy()->willReturn($this->policy->reveal());
+
+    $this->cspEventSubscriber = new CspEventSubscriber();
+  }
+
+  /**
+   * Tests the getSubscribedEvents method.
+   *
+   * @covers ::getSubscribedEvents
+   */
+  public function testGetSubscribedEvents(): void {
+    $this->assertEquals([CspEvents::POLICY_ALTER => 'policyAlter'], CspEventSubscriber::getSubscribedEvents());
+  }
+
+  /**
+   * Tests policy alteration.
+   *
+   * @covers ::policyAlter
+   */
+  public function testPolicyAlterWithLocalEnvironment(): void {
+    $this->policy->fallbackAwareAppendIfEnabled('frame-src', Argument::any())->shouldBeCalled();
+    $this->policy->fallbackAwareAppendIfEnabled('script-src', Argument::any())->shouldBeCalled();
+
+    $this->cspEventSubscriber->policyAlter($this->event->reveal());
+  }
+
+}


### PR DESCRIPTION
# [UHF-11974](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11974)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Moved CSP rules from global config to proper context in code.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git checkout UHF-11974`
  * `make fresh`
* Update the Helfi Platform config and Hdbt theme
  * `composer require -W drupal/helfi_platform_config:dev-UHF-11974 drupal/hdbt:dev-UHF-11974`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Go to https://kaupunkitieto.docker.so/fi/tyhjeneva-keskusta-huolettaa-kaupunkilaisten-nakokulmia-helsingin-keskusta-alueen-kehittamiseen
  * [ ] The charts from infogram should load without issues
  * [ ] Check console; you should not see CSP related errors
* Go to https://kaupunkitieto.docker.so/fi/vaesto/vaestonmuutokset/vaeston-kehitys
  * [ ] The charts from PowerBI should load without issues
  * [ ] Check console; you should not see CSP related errors
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1068
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1371
* https://github.com/City-of-Helsinki/drupal-infofinland/pull/477


[UHF-11974]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ